### PR TITLE
Extend ServoRudderStatus with actual position and fault cause

### DIFF
--- a/CAN_MESSAGES.md
+++ b/CAN_MESSAGES.md
@@ -56,10 +56,12 @@ Any state byte value not listed maps to `Unknown` on the receiver side.
 
 | Message | CAN ID | DLC | Byte | Field | Type | Endian | Values / Range |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| ServoRudderSetpoint | 0x010 | 2 | 0–1 | Setpoint | u16 | LE | 1000–2000 |
-| ServoRudderStatus | 0x020 | 3 | 0 | State | u8 enum | | 0=Uninitialized, 1=Operational, 0xFF=Unknown |
+| ServoRudderSetpoint | 0x010 | 2 | 0–1 | Setpoint | u16 | LE | 1000–2000. Out-of-range values are rejected by the rudder controller and do not feed its 2 s communication watchdog. |
+| ServoRudderStatus | 0x020 | 6 | 0 | State | u8 enum | | 0=Uninitialized, 1=Operational, 2=Homing, 3=FailSafe, 4=Fault, 0xFF=Unknown |
 | | | | 1–2 | Current setpoint | u16 | LE | 1000–2000 |
-| ServoRudderCommand | 0x021 | 1 | 0 | Command | u8 enum | | 0=Initialize |
+| | | | 3–4 | Actual position | u16 | LE | 1000–2000, in setpoint units. Sent every 100 ms. |
+| | | | 5 | Fault cause | u8 enum | | 0=None, 1=StallDuringMove, 2=HomingTimeout, 3=DriverNoUartResponse, 4=DriverError |
+| ServoRudderCommand | 0x021 | 1 | 0 | Command | u8 enum | | 0=Initialize. Starts (re-)homing from any state; required to leave FailSafe or Fault. |
 | RudderControllerCoolingPumpStatus | 0x212 | 1 | 0 | Fault input level | u8 | | Raw PC5 level: 0=fault asserted (low), 1=ok (high). Sent every 1 s. |
 | SteeringAngle | 0x213 | 4 | 0–1 | Angle | i16 | LE | -180 to +180 degrees. Sent every 100 ms. |
 | | | | 2–3 | Raw ADC | u16 | LE | 0–4095 (12-bit). Linear mapping: 0=-180°, 4095=+180°. |

--- a/eoi-can-decoder/src/lib.rs
+++ b/eoi-can-decoder/src/lib.rs
@@ -617,6 +617,8 @@ impl From<u8> for ServoRudderCommand {
 pub struct ServoStatus {
     pub state: ServoState,
     pub setpoint: u16,
+    pub actual_position: u16,
+    pub fault_cause: ServoFaultCause,
 }
 
 #[derive(Debug, Serialize, Default, PartialEq)]
@@ -625,6 +627,9 @@ pub enum ServoState {
     #[default]
     Uninitialized,
     Operational,
+    Homing,
+    FailSafe,
+    Fault,
     Unknown,
 }
 
@@ -633,7 +638,34 @@ impl From<u8> for ServoState {
         match value {
             0 => Self::Uninitialized,
             1 => Self::Operational,
-            0xFF => Self::Unknown,
+            2 => Self::Homing,
+            3 => Self::FailSafe,
+            4 => Self::Fault,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Default, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ServoFaultCause {
+    #[default]
+    None,
+    StallDuringMove,
+    HomingTimeout,
+    DriverNoUartResponse,
+    DriverError,
+    Unknown,
+}
+
+impl From<u8> for ServoFaultCause {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => Self::None,
+            1 => Self::StallDuringMove,
+            2 => Self::HomingTimeout,
+            3 => Self::DriverNoUartResponse,
+            4 => Self::DriverError,
             _ => Self::Unknown,
         }
     }
@@ -755,6 +787,8 @@ pub fn parse_eoi_can_data(can_frame: &can_frame::CanFrame) -> Option<EoiCanData>
             ServoData::Status(ServoStatus {
                 state: (*data.first()?).into(),
                 setpoint: bytes_le_to_u16(data.get(1..3)?)?,
+                actual_position: bytes_le_to_u16(data.get(3..5)?)?,
+                fault_cause: (*data.get(5)?).into(),
             }),
         ))),
         0x212 => Some(EoiCanData::RudderController(
@@ -1307,7 +1341,8 @@ mod tests {
     fn servo_rudder_status() {
         let can_frame = can_frame::CanFrame::from_encoded(
             embedded_can::Id::Standard(StandardId::new(0x20).unwrap()),
-            &[0x01, 0xD0, 0x07], // Operational, setpoint=2000 little-endian
+            // Operational, setpoint=2000 LE, actual position=1500 LE, fault cause=None
+            &[0x01, 0xD0, 0x07, 0xDC, 0x05, 0x00],
         );
         let data = parse_eoi_can_data(&can_frame).unwrap();
         let EoiCanData::RudderController(RudderControllerData::Servo(ServoData::Status(status))) =
@@ -1317,6 +1352,27 @@ mod tests {
         };
         assert!(status.state == ServoState::Operational);
         assert!(status.setpoint == 2000);
+        assert!(status.actual_position == 1500);
+        assert!(status.fault_cause == ServoFaultCause::None);
+    }
+
+    #[test]
+    fn servo_rudder_status_fault() {
+        let can_frame = can_frame::CanFrame::from_encoded(
+            embedded_can::Id::Standard(StandardId::new(0x20).unwrap()),
+            // Fault, setpoint=1000 LE, actual position=1000 LE, fault cause=StallDuringMove
+            &[0x04, 0xE8, 0x03, 0xE8, 0x03, 0x01],
+        );
+        let data = parse_eoi_can_data(&can_frame).unwrap();
+        let EoiCanData::RudderController(RudderControllerData::Servo(ServoData::Status(status))) =
+            data
+        else {
+            panic!("Unexpected data type");
+        };
+        assert!(status.state == ServoState::Fault);
+        assert!(status.setpoint == 1000);
+        assert!(status.actual_position == 1000);
+        assert!(status.fault_cause == ServoFaultCause::StallDuringMove);
     }
 
     #[test]

--- a/eoi-can-display-firmware/src/inverted_display.rs
+++ b/eoi-can-display-firmware/src/inverted_display.rs
@@ -39,12 +39,13 @@ impl DrawTarget for EpdDisplay {
     where
         I: IntoIterator<Item = Pixel<Self::Color>>,
     {
-        self.0.draw_iter(pixels.into_iter().map(|Pixel(point, color)| {
-            let color = match color {
-                BinaryColor::On => Color::White,
-                BinaryColor::Off => Color::Black,
-            };
-            Pixel(point, color)
-        }))
+        self.0
+            .draw_iter(pixels.into_iter().map(|Pixel(point, color)| {
+                let color = match color {
+                    BinaryColor::On => Color::White,
+                    BinaryColor::Off => Color::Black,
+                };
+                Pixel(point, color)
+            }))
     }
 }

--- a/eoi-can-to-mqtt/src/ha_discovery.rs
+++ b/eoi-can-to-mqtt/src/ha_discovery.rs
@@ -1016,7 +1016,25 @@ fn add_rudder(v: &mut Vec<HaEntity>) {
             "RudderController.Servo.Status.setpoint",
         )
         .measurement()
-        .diagnostic(),
+        .icon("mdi:ship-wheel"),
+    );
+    v.push(
+        sensor(
+            "rudder_status_actual_position",
+            "Rudder Status Actual Position",
+            "RudderController.Servo.Status.actual_position",
+        )
+        .measurement()
+        .icon("mdi:ship-wheel"),
+    );
+    v.push(
+        sensor(
+            "rudder_status_fault_cause",
+            "Rudder Status Fault Cause",
+            "RudderController.Servo.Status.fault_cause",
+        )
+        .diagnostic()
+        .icon("mdi:console"),
     );
     v.push(
         sensor(
@@ -1637,6 +1655,8 @@ mod tests {
                 ServoStatus {
                     state: ServoState::Operational,
                     setpoint: 0,
+                    actual_position: 0,
+                    fault_cause: ServoFaultCause::None,
                 },
             ))),
             EoiCanData::RudderController(RudderControllerData::Servo(ServoData::Command(


### PR DESCRIPTION
## Summary

Protocol support for the rudder servo firmware (Engineers-of-Innovation/staartstuk-controller#1):

- `ServoState` gains `Homing=2`, `FailSafe=3`, `Fault=4`.
- `ServoRudderStatus` (0x020) grows from 3 to 6 bytes: actual position (u16 LE, setpoint units) and a fault-cause byte (`0=None, 1=StallDuringMove, 2=HomingTimeout, 3=DriverNoUartResponse, 4=DriverError`).
- `CAN_MESSAGES.md` updated, including the rule that out-of-range setpoints are rejected by the rudder controller and do not feed its 2 s watchdog.

Old 3-byte status frames no longer decode (return `None`), which is fine since the only sender is the rudder controller firmware that ships with this change.

## Test plan

`cargo test` passes (34 tests, including new 6-byte status decode tests for the nominal and fault cases); `cargo check --features defmt` (no_std build) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)